### PR TITLE
Battle cutscene functions comments and names

### DIFF
--- a/disasm/code/common/scripting/battlecutscenefunctions.asm
+++ b/disasm/code/common/scripting/battlecutscenefunctions.asm
@@ -115,86 +115,103 @@ WasEntityKilledByLastAttack:
 
 
 ; =============== S U B R O U T I N E =======================================
+; Flickers the selected sprite qucikly at first, slowing down over time
+; Only used to make Darksol reappear on Dark Dragon's body in cutscene
+; after battle 28
+;
+; In:
+; D0	The index of the sprite to flicker
 
-sub_12BFF0:
+flickerSprite_Reappear:
 		move.w  d0,d7
 		lsl.w   #3,d7
 		lea     (SPRITE_22_PROPERTIES).l,a0
 		adda.w  d7,a0
-		moveq   #1,d1
-		moveq   #1,d2
-		moveq   #$1D,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #3,d2
-		moveq   #9,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #5,d2
-		moveq   #4,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #9,d2
-		moveq   #2,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #$13,d2
-		moveq   #2,d7
-		bsr.w   sub_12C080
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #1,d2							; Flicker on 1 frame
+		moveq   #$1D,d7							; Repeat 30 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #3,d2							; Flicker on 3 frames
+		moveq   #9,d7							; Repeat 10 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #5,d2							; Flicker on 5 frames
+		moveq   #4,d7							; Repeat 5 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #9,d2							; Flicker on 9 frames
+		moveq   #2,d7							; Repeat 3 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #$13,d2							; Flicker on 19 frames
+		moveq   #2,d7							; Repeat 3 times
+		bsr.w   flickerSprite
 		moveq   #30,d0
 		jmp     (j_Sleep).l
 
-    ; End of function sub_12BFF0
+    ; End of function flickerSprite_Reappear
 
 
 ; =============== S U B R O U T I N E =======================================
+; Flickers the selected sprite slowly at first, speeding up over time
+;
+; In:
+; D0	The index of the sprite to flicker
 
-sub_12C036:
+flickerSprite_Disappear:
 		move.w  d0,d7
 		lsl.w   #3,d7
 		lea     (SPRITE_22_PROPERTIES).l,a0
 		adda.w  d7,a0
-		moveq   #1,d1
-		moveq   #$13,d2
-		moveq   #2,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #9,d2
-		moveq   #2,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #5,d2
-		moveq   #4,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #3,d2
-		moveq   #9,d7
-		bsr.w   sub_12C080
-		moveq   #1,d1
-		moveq   #1,d2
-		moveq   #$1D,d7
-		bsr.w   sub_12C080
-		eori.w  #$100,(a0)
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #$13,d2							; Flicker on 19 frames
+		moveq   #2,d7							; Repeat 3 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #9,d2							; Flicker on 9 frames
+		moveq   #2,d7							; Repeat 3 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #5,d2							; Flicker on 5 frames
+		moveq   #4,d7							; Repeat 5 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #3,d2							; Flicker on 3 frames
+		moveq   #9,d7							; Repeat 10 times
+		bsr.w   flickerSprite
+		moveq   #1,d1							; Flicker off 1 frame
+		moveq   #1,d2							; Flicker on 1 frame
+		moveq   #$1D,d7							; Repeat 30 times
+		bsr.w   flickerSprite
+		eori.w  #$100,(a0)						; Make sprite disappear again
 		moveq   #30,d0
 		jmp     (j_Sleep).l
 
-    ; End of function sub_12C036
+    ; End of function flickerSprite_Disappear
 
 
 ; =============== S U B R O U T I N E =======================================
+; Flickers the selected sprite
+;
+; In:
+; A0	The properties address of the sprite to flicker
+; D1	Number of frames to disappear
+; D2	Number of frames to reappear
+; D7	Number of times to perform the flicker
 
-sub_12C080:
+flickerSprite:
 		eori.w  #$100,(a0)
 		move.w  d1,d0
 		jsr     (j_Sleep).l
 		eori.w  #$100,(a0)
 		move.w  d2,d0
 		jsr     (j_Sleep).l
-		dbf     d7,sub_12C080
+		dbf     d7,flickerSprite
                 
 		rts
 
-    ; End of function sub_12C080
+    ; End of function flickerSprite
 
 
 ; =============== S U B R O U T I N E =======================================

--- a/disasm/code/common/scripting/beforebattlecutscenes.asm
+++ b/disasm/code/common/scripting/beforebattlecutscenes.asm
@@ -538,7 +538,7 @@ byte_129608:
 		bsr.w   FindEntityForCutscene
 		tst.w   d0
 		blt.s   loc_129628
-		bsr.w   sub_12C036
+		bsr.w   flickerSprite_Disappear
 loc_129628:
 		move.w  #NPC00,d2
 		bsr.w   FindEntityForCutscene
@@ -647,7 +647,7 @@ byte_129760:
 		bsr.w   FindEntityForCutscene
 		tst.w   d0
 		blt.s   loc_129778
-		bsr.w   sub_12C036
+		bsr.w   flickerSprite_Disappear
 loc_129778:
 		move.w  #NPC00,d2
 		bsr.w   FindEntityForCutscene

--- a/disasm/code/common/scripting/endofbattlecutscenes.asm
+++ b/disasm/code/common/scripting/endofbattlecutscenes.asm
@@ -420,7 +420,7 @@ byte_12A892:
 		bsr.w   FindEntityForCutscene
 		tst.w   d0
 		blt.s   loc_12A8D0
-		bsr.w   sub_12C036
+		bsr.w   flickerSprite_Disappear
 loc_12A8D0:
 		move.w  #NPC00,d2
 		bsr.w   FindEntityForCutscene
@@ -631,7 +631,7 @@ byte_12AA98:
 		bsr.w   FindEntityForCutscene
 		tst.w   d0
 		blt.s   loc_12AABE
-		bsr.w   sub_12C036
+		bsr.w   flickerSprite_Disappear
 loc_12AABE:
 		move.w  #NPC00,d2
 		bsr.w   FindEntityForCutscene
@@ -664,7 +664,7 @@ loc_12AAD6:
 		bsr.w   FindEntityForCutscene
 		tst.w   d0
 		blt.s   loc_12AB3A
-		bsr.w   sub_12BFF0
+		bsr.w   flickerSprite_Reappear
 loc_12AB3A:
 		moveq   #PORTRAIT_DARKSOL,d0
 		jsr     j_OpenPortraitWindow
@@ -676,7 +676,7 @@ loc_12AB3A:
 		bsr.w   FindEntityForCutscene
 		tst.w   d0
 		blt.s   loc_12AB62
-		bsr.w   sub_12C036
+		bsr.w   flickerSprite_Disappear
 loc_12AB62:
 		move.w  #NPC00,d2
 		bsr.w   FindEntityForCutscene


### PR DESCRIPTION
Added names and comments to 3 functions in battlecutscenefunctions.asm to better illustrate their purposes.
All uses of the functions names have been updated accordingly.

sub_12BFF0    -> flickerSprite_Reappear
This is only used once in edcs28 to make Darksol reappear on Dark Dragon's back.

sub_12C036    -> flickerSprite_Disappear
This is used once in edcs18 and twice in edcs28 to make Kane and Darksol disappear respectively.

sub_12C080    -> flickerSprite
This is only used by the above two functions to perform the flicker on the sprite.

ROM builds successfully with no differences.